### PR TITLE
이상민 / 8월 8일 / 개인문제

### DIFF
--- a/백준/Gold/32259. 가짜 금화 찾기/README.md
+++ b/백준/Gold/32259. 가짜 금화 찾기/README.md
@@ -1,0 +1,65 @@
+# [Gold IV] 가짜 금화 찾기 - 32259 
+
+[문제 링크](https://www.acmicpc.net/problem/32259) 
+
+### 성능 요약
+
+메모리: 13808 KB, 시간: 32 ms
+
+### 분류
+
+삼분 탐색
+
+### 제출 일자
+
+2025년 8월 8일 09:42:26
+
+### 문제 설명
+
+<p>준혁이는 번호가 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c31"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>1</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$1$</span></mjx-container>부터 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>N</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$N$</span></mjx-container>까지 쓰여 있는 금화 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>N</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$N$</span></mjx-container>개를 가지고 있다. 쓰여 있는 번호가 그 동전의 번호이다.</p>
+
+<p>어느 날 준혁이는 자신이 가지고 있는 금화 중 하나가 가짜 금화라는 소식을 알았다. 진짜 금화들의 무게는 모두 같지만 가짜 금화는 진짜 금화보다 무게가 가볍다.</p>
+
+<p>준혁이는 가짜 금화를 찾아내기 위해 양팔 저울을 빌렸다. 양팔 저울을 이용하면 두 금화 묶음의 무게를 비교할 수 있다. 금화 묶음은 서로 다른 금화를 여러 개 모아놓은 것이다. 금화 묶음의 크기는 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c30"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>0</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$0$</span></mjx-container> 이상 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>N</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$N$</span></mjx-container> 이하여야 한다.</p>
+
+<p>알고리즘 공부를 하느라고 바쁜 준혁이는 양팔 저울을 최대 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c35"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>5</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$5$</span></mjx-container>회만 사용하려고 한다. 준혁이를 도와 양팔 저울을 적절히 활용하여 가짜 금화가 몇 번 금화인지 찾아내자.</p>
+
+### 입력 
+
+ <p>첫째 줄에 동전의 수 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>N</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$N$</span></mjx-container>이 입력된다. <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mo class="mjx-n"><mjx-c class="mjx-c28"></mjx-c></mjx-mo><mjx-mn class="mjx-n"><mjx-c class="mjx-c31"></mjx-c></mjx-mn><mjx-mo class="mjx-n" space="4"><mjx-c class="mjx-c2264"></mjx-c></mjx-mo><mjx-mi class="mjx-i" space="4"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi><mjx-mo class="mjx-n" space="4"><mjx-c class="mjx-c2264"></mjx-c></mjx-mo><mjx-mn class="mjx-n" space="4"><mjx-c class="mjx-c31"></mjx-c><mjx-c class="mjx-c32"></mjx-c><mjx-c class="mjx-c38"></mjx-c></mjx-mn><mjx-mo class="mjx-n"><mjx-c class="mjx-c29"></mjx-c></mjx-mo></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mo stretchy="false">(</mo><mn>1</mn><mo>≤</mo><mi>N</mi><mo>≤</mo><mn>128</mn><mo stretchy="false">)</mo></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$(1 ≤ N ≤ 128)$</span> </mjx-container></p>
+
+### 출력 
+
+ <p><mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"> <mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>N</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$N$</span></mjx-container>이 입력된 후로는 프로그램과 채점 시스템이 상호작용하며 실행된다.</p>
+
+<p>프로그램은 채점 시스템에게 다음과 같은 질문을 최대 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c35"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>5</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$5$</span></mjx-container>회 할 수 있다.</p>
+
+<ul>
+	<li><code>? A 0 B 0</code>: 첫번째 금화 묶음 A와 두번째 금화 묶음 B의 무게를 비교해 결과를 물어보는 질문이다. 금화 묶음을 출력할 때는 금화 묶음에 속한 금화들을 아무 순서로 공백으로 구분하여 출력하고 금화 묶음에 있는 동전을 모두 출력했음을 의미하는 <code>0</code>을 출력하면 된다. 금화의 번호는 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c31"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>1</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$1$</span></mjx-container>과 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>N</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$N$</span></mjx-container> 사이 정수이고 하나의 금화 묶음에 같은 동전이 2개 있을 수 없고, 금화 하나가 두 묶음에 전부 포함될 수 없다.</li>
+</ul>
+
+<p>채점 시스템에 질문을 출력하면 채점 시스템의 답변이 입력된다.</p>
+
+<ul>
+	<li><code><</code>: 금화 묶음 A가 더 가볍다.</li>
+	<li><code>></code>: 금화 묶음 B가 더 가볍다.</li>
+	<li><code>=</code>: 두 금화 묶음의 무게가 같다.</li>
+</ul>
+
+<p>정답을 알아냈을 때는 다음과 같이 출력한다. </p>
+
+<ul>
+	<li><code>!</code> <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D465 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$x$</span></mjx-container>: 가짜 금화의 번호가 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D465 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$x$</span></mjx-container>이다.</li>
+</ul>
+
+<p>이 출력 이후에는 프로그램을 종료한다. 더 자세한 입출력 형식은 예제를 참고하자.</p>
+
+<p><strong>모든 출력 이후에는 버퍼를 flush 해야 한다.</strong> 언어별 표준 출력 버퍼를 flush 하는 방법은 다음과 같다.</p>
+
+<ul>
+	<li>C: <code>fflush(stdout)</code></li>
+	<li>C++: <code>std::cout << std::flush</code></li>
+	<li>Java: <code>System.out.flush()</code></li>
+	<li>Python: <code>sys.stdout.flush()</code></li>
+</ul>
+

--- a/백준/Gold/32259. 가짜 금화 찾기/가짜 금화 찾기.py
+++ b/백준/Gold/32259. 가짜 금화 찾기/가짜 금화 찾기.py
@@ -1,0 +1,50 @@
+import sys
+input = sys.stdin.readline
+
+def question(s, m, e):
+    arr = ["?"]
+    for i in range(s, m):
+        arr.append(i)
+    arr.append(0)
+    for i in range(m, e):
+        arr.append(i)
+    arr.append(0)
+    print(*arr, flush=True)
+    return
+
+n = int(input())
+start = 1
+end = n
+unit = (end - start + 1) // 3
+
+while unit != 0:
+    mid_f = start + unit
+    mid_s = mid_f + unit
+    question(start, mid_f, mid_s)
+    ans = input().rstrip()
+    if ans == "<":
+        if mid_f - start == 1:
+            print(f"! {start}", flush=True)
+            break
+        else:
+            end = mid_f
+    elif ans == ">":
+        if mid_s - mid_f == 1:
+            print(f"! {mid_f}", flush=True)
+            break
+        else:
+            start = mid_f
+            end = mid_s
+    else:
+        start = mid_s
+    unit = (end - start + 1) // 3
+
+if start == end:
+    print(f"! {start}", flush=True)
+elif end - start == 1:
+    print(f"? {start} 0 {end} 0", flush=True)
+    ans = input().rstrip()
+    if ans == "<":
+        print(f"! {start}", flush=True)
+    elif ans == ">":
+        print(f"! {end}", flush=True)


### PR DESCRIPTION
## 가짜 금화 찾기
처음에는 금화를 반씩 나눠가면서 더 작은 것을 찾으려고 했는데.. n의 최대가 128이라서 2의 7제곱이라서 최악의 경우 저울을 7번 사용해야 해서 안되네요.
그래서 알고리즘 분류를 봤더니 삼분 탐색이라는 개념이 있었습니다.
정석적인 풀이는 아닐 것 같지만 이분 탐색과 달리 구간을 3개로 쪼개서 start, mid_first, mid_second, end 4개의 변수를 다루었고,
3개로 쪼갠 구간 중 2개의 구간의 무게를 비교해보고 어느 한쪽이 작으면 그 구간을, 둘의 무게가 같으면 탐색하지 않은 구간으로 좁혀 나갔습니다.
마지막에 구간이 1개, 혹은 2개 남았을 때는 구간을 3개로 쪼갤 수 없으니 이 부분을 처리하는 로직까지 만들었습니다.
채점 서버와 실시간으로 문답을 주고받는 과정에서 출력 버퍼라는 개념까지 소소하게 얻고 가니 재밌네요.