### PR TITLE
이상민 / 8월 22일 / 개인문제

### DIFF
--- a/백준/Gold/29737. 브실이는 잔디가 좋아 🌱/README.md
+++ b/백준/Gold/29737. 브실이는 잔디가 좋아 🌱/README.md
@@ -1,0 +1,67 @@
+# [Gold IV] 브실이는 잔디가 좋아 🌱 - 29737 
+
+[문제 링크](https://www.acmicpc.net/problem/29737) 
+
+### 성능 요약
+
+메모리: 32412 KB, 시간: 60 ms
+
+### 분류
+
+구현, 정렬
+
+### 제출 일자
+
+2025년 8월 22일 09:21:50
+
+### 문제 설명
+
+<p style="text-align: center;"><img alt="" src="https://upload.acmicpc.net/ebd5c73e-5491-47bf-9d0d-02f0bdc50662/-/preview/" style="max-width: 100%; height: 229px; width: 400px;"></p>
+
+<p>문제를 풀기 전 스트릭과 스트릭 프리즈에 대해서 알아보자!</p>
+
+<blockquote>
+<p><strong>스트릭(Streak)</strong>이란?</p>
+</blockquote>
+
+<p style="text-align: center;"><img alt="" src="https://upload.acmicpc.net/55571ac9-ee39-4a35-ad31-6571e89e67a2/-/preview/" style="width: 100px; height: 100px;"></p>
+
+<p>스트릭은 연속해서 문제를 푼 날의 수를 의미한다. 한 문제를 풀어서 <span class="result-ac">맞았습니다!!</span> 결과를 얻게 되면 당일 스트릭을 달성한다. 스트릭은 매일 연속으로 한 문제 이상을 <span class="result-ac">맞았습니다!!</span> 결과를 받아야 증가하며, 문제를 풀지 못한 시점부터 스트릭은 다시 0(일)으로 초기화된다. 연속해서 문제를 푼 날의 수가 많을 수록 스트릭의 길이가 길며, 길이가 가장 긴 스트릭을 최장 스트릭이라고 한다.</p>
+
+<blockquote>
+<p><strong>스트릭 프리즈(Streak Freeze)</strong>란?</p>
+</blockquote>
+
+<p style="text-align: center;"><img alt="스트릭 프리즈" src="https://static.solved.ac/item/freeze-small-simple.svg" style="height: 100px; width: 100px;"></p>
+
+<p><a href="https://solved.ac/coin/shop">solved.ac 코인샵</a>에서 문제를 풀어 별조각을 모아 구매할 수 있는 아이템이다. 미리 이 아이템을 사둔다면 당일에 한 문제도 못 풀어도 스트릭을 0(일)으로 초기화되는 것을 막아준다. 하지만 초기화가 되는 것을 막아줄 뿐, 당일 스트릭 길이는 증가하지 않는다.</p>
+
+<p>브실이는 대한민국 최강 코딩 마스터가 되기 위해 오늘도 하루에 한 문제 이상을 푸는 오스완(오늘 스트릭 완료)을 해야 한다. 브실이는 동기부여를 받기 위해 <a href="https://solved.ac/">solved.ac</a>에 있는 <a href="https://solved.ac/ranking/streak">최장 스트릭 랭킹</a>을 보았다. 동기부여를 받기는커녕 자신감만 잃은 브실이는 친구들의 스트릭을 보고, 순위를 매겨보기로 했다. 브실이 친구들이 특정 기간 동안 문제를 푼 결과가 주어질 때 해당 기간 브실이 친구들의 순위를 매겨 보자! </p>
+
+<p>브실이는 아래의 우선순위를 차례대로 적용하여 친구들의 순위를 매긴다.</p>
+
+<ol>
+	<li>가장 긴 최장 스트릭을 가진 친구</li>
+	<li>최장 스트릭 내의 더 적은 개수의 스트릭 프리즈를 사용한 친구</li>
+	<li>최장 스트릭을 시작한 날짜가 더 이른 친구</li>
+	<li>스트릭 프리즈 사용한 날짜를 제외하고 스트릭 달성에 실패한 날짜 수가 적은 친구</li>
+</ol>
+
+<p>단, 최장 스트릭은 스트릭 프리즈로 시작하거나 끝날 수 없다.</p>
+
+<p>위 순위 결정에도 순위가 같다면 순위는 같게 하고 닉네임의 사전 순으로 출력하며 그다음 순위는 이전 순위에 1을 더한 값으로 한다. 한 친구의 최장 스트릭이 여럿일 경우에는 가능한 한 우선순위가 높도록 하는 것을 고른다. 이때 선택되는 최장 스트릭은 유일하다. 문제를 푼 결과는 알파벳 대문자 <span data-darkreader-inline-color="" style="color: rgb(231, 76, 60); --darkreader-inline-color: #e95849;"><code>O</code></span>, <span data-darkreader-inline-color="" style="color: rgb(231, 76, 60); --darkreader-inline-color: #e95849;"><code>X</code></span>, <code><span data-darkreader-inline-color="" style="color: rgb(231, 76, 60); --darkreader-inline-color: #e95849;">F</span></code>로 주어지며, <span data-darkreader-inline-color="" style="color: rgb(231, 76, 60); --darkreader-inline-color: #e95849;"><code>O</code></span>는 문제 해결 성공, <code><span data-darkreader-inline-color="" style="color: rgb(231, 76, 60); --darkreader-inline-color: #e95849;">X</span></code>는 문제 해결 실패, <code><span data-darkreader-inline-color="" style="color: rgb(231, 76, 60); --darkreader-inline-color: #e95849;">F</span></code>는 스트릭 프리즈를 나타낸다.</p>
+
+### 입력 
+
+ <p>첫 번째 줄에는 브실이의 친구 수 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>N</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$N$</span></mjx-container>과 스트릭 기간에 포함된 주 수 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D44A TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>W</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$W$</span></mjx-container>가 공백으로 구분되어 주어진다. <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mo class="mjx-n"><mjx-c class="mjx-c28"></mjx-c></mjx-mo><mjx-mn class="mjx-n"><mjx-c class="mjx-c31"></mjx-c></mjx-mn><mjx-mo class="mjx-n" space="4"><mjx-c class="mjx-c2264"></mjx-c></mjx-mo><mjx-mi class="mjx-i" space="4"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi><mjx-mo class="mjx-n"><mjx-c class="mjx-c2C"></mjx-c></mjx-mo><mjx-mi class="mjx-i" space="2"><mjx-c class="mjx-c1D44A TEX-I"></mjx-c></mjx-mi><mjx-mo class="mjx-n" space="4"><mjx-c class="mjx-c2264"></mjx-c></mjx-mo><mjx-mn class="mjx-n" space="4"><mjx-c class="mjx-c31"></mjx-c><mjx-c class="mjx-c30"></mjx-c><mjx-c class="mjx-c30"></mjx-c></mjx-mn><mjx-mo class="mjx-n"><mjx-c class="mjx-c29"></mjx-c></mjx-mo></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mo stretchy="false">(</mo><mn>1</mn><mo>≤</mo><mi>N</mi><mo>,</mo><mi>W</mi><mo>≤</mo><mn>100</mn><mo stretchy="false">)</mo></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$(1 \le N, W \le 100)$</span> </mjx-container></p>
+
+<p>두 번째 줄부터는 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>N</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$N$</span></mjx-container>명의 브실이 친구들이 문제를 푼 결과가 각자의 아이디와 함께 주어진다.</p>
+
+<p>정보의 첫 번째 줄에는 브실이 친구의 아이디 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D446 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>S</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$S$</span></mjx-container>가 주어지며, 두 번째 줄부터 친구의 스트릭이 가로 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D44A TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>W</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$W$</span></mjx-container>줄 세로 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c37"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>7</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$7$</span></mjx-container>줄 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c37"></mjx-c></mjx-mn><mjx-mo class="mjx-n" space="3"><mjx-c class="mjx-cD7"></mjx-c></mjx-mo><mjx-mi class="mjx-i" space="3"><mjx-c class="mjx-c1D44A TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>7</mn><mo>×</mo><mi>W</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$7 \times W$</span></mjx-container> 형태로 주어진다. <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D456 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>i</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$i$</span></mjx-container>행 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D457 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>j</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$j$</span></mjx-container>열은 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c37"></mjx-c></mjx-mn><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D457 TEX-I"></mjx-c></mjx-mi><mjx-mo class="mjx-n" space="3"><mjx-c class="mjx-c2B"></mjx-c></mjx-mo><mjx-mi class="mjx-i" space="3"><mjx-c class="mjx-c1D456 TEX-I"></mjx-c></mjx-mi><mjx-mo class="mjx-n" space="3"><mjx-c class="mjx-c2B"></mjx-c></mjx-mo><mjx-mn class="mjx-n" space="3"><mjx-c class="mjx-c31"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>7</mn><mi>j</mi><mo>+</mo><mi>i</mi><mo>+</mo><mn>1</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$7j + i + 1$</span></mjx-container>번째 날을 나타낸다.</p>
+
+<p>친구들의 아이디 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D446 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>S</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$S$</span></mjx-container>는 중복이 없으며, <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D446 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>S</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$S$</span></mjx-container>는 알파벳 소문자로만 이루어진 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c31"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>1</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$1$</span></mjx-container> 이상 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c31"></mjx-c><mjx-c class="mjx-c30"></mjx-c><mjx-c class="mjx-c30"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>100</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$100$</span></mjx-container> 이하의 문자열이다.</p>
+
+### 출력 
+
+ <p><mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"> <mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>N</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$N$</span></mjx-container>개의 줄에 걸쳐, 본문에서 정의한 우선순위로 정렬된 브실이 친구들의 순위와 닉네임을 <span data-darkreader-inline-color="" style="color: rgb(231, 76, 60); --darkreader-inline-color: #e95849;"><code>"{순위}. {닉네임}"</code></span>의 형식으로 출력한다.</p>
+

--- a/백준/Gold/29737. 브실이는 잔디가 좋아 🌱/브실이는 잔디가 좋아 🌱.py
+++ b/백준/Gold/29737. 브실이는 잔디가 좋아 🌱/브실이는 잔디가 좋아 🌱.py
@@ -1,0 +1,66 @@
+import sys
+input = sys.stdin.readline
+
+def solve(record):
+    idx = 0
+    strick = []
+    fail = 0
+    while idx < len(record):
+        if record[idx] == "O":
+            start = idx
+            used = 0
+            length = 0
+            last_strick_stack = 0
+            last_strick = False
+            while idx < len(record):
+                if record[idx] == "O":
+                    length += 1
+                    last_strick_stack = 0
+                    last_strick = False
+                elif record[idx] == "X":
+                    if last_strick:
+                        last_strick = False
+                        used -= last_strick_stack
+                    fail += 1
+                    break
+                else:
+                    used += 1
+                    last_strick_stack += 1
+                    last_strick = True
+                idx += 1
+            if last_strick:
+                used -= last_strick_stack
+            strick.append([length, used, start])
+            continue
+        elif record[idx] == "X":
+            fail += 1
+        idx += 1
+    strick.sort(key=lambda x: (-x[0], x[1], x[2]))
+    if not strick:
+        strick.append([0, 0, 0])
+    strick[0].append(fail)
+    return strick[0]
+
+n, w = map(int, input().split())
+solved = []
+for _ in range(n):
+    nickname = input().rstrip()
+    arr = [input().rstrip() for _ in range(7)]
+    day = ""
+    for i in range(w):
+        for j in range(7):
+            day += arr[j][i]
+    solved.append(solve(day) + [nickname])
+solved.sort(key=lambda x: (-x[0], x[1], x[2], x[3], x[4]))
+
+solved[0].append(1)
+rank = 1
+for i in range(1, n):
+    if solved[i][0] == solved[i-1][0] and solved[i][1] == solved[i-1][1] and solved[i][2] == solved[i-1][2] and solved[i][3] == solved[i-1][3]:
+        pass
+    else:
+        rank += 1
+    solved[i].append(rank)
+
+for i in range(n):
+    print(f"{solved[i][-1]}. {solved[i][-2]}")


### PR DESCRIPTION
삼성전자 연계 특화프로젝트와 공통 프로젝트 우수팀으로 선정되는 영광으로 인해 몹시 바빴네요.. 이번 주에만 스트릭 프리즈 2개나 썼어요 흑흑

## 브실이는 잔디가 좋아 🌱
특별한 알고리즘이 따로 없는 구현 문제입니다.
그럼에도 골드 4티어라는건 굉장히 조건이 어렵다는 뜻이죠... 불길한 예감이 현실이 되었습니다

1. 스트릭을 계산하기 위한 달력 배열이 흔히 아는 가로 정렬이 아니라 세로로 정렬되어 있습니다. 이 점에 유의해서 하나의 연속된 문자열로 합칩니다.
2. 전체 기간 중 이어진 모든 스트릭을 알아보기 위한 임시 배열과 실패 날짜수 변수를 만들어줍니다.
3. 달력 문자열을 순회하면서 O(정답)인 날을 발견하면 그 날부터 스트릭을 이어가봅니다. 내부에 다시 while 반복문으로 스트릭이 끊길 때까지 스트릭의 길이를 연장합니다.
    - 스트릭은 O로만 이어지고, F(프리즈 사용)에는 스트릭 길이가 늘어나지 않습니다.
    - X를 만나면 내부의 반복문을 탈출합니다.
    - 스트릭이 F로 끝날 수 없다고 했기 때문에 스트릭의 맨 끝에 이어진 F의 개수만큼은 사용한 스트릭 프리즈 개수에서 빼 줘야 하는데요(예시: OOFOOFFFX -> 길이 4(8 아님), 사용 프리즈 1(4 아님)), 이를 위해 내부 반복문에서 스트릭이 끊기기 바로 직전에 F가 있었는지, 그 길이는 얼마인지를 확인한 변수를 만들었습니다. 생각해보니 존재 유무 bool형 변수를 만들 필요는 없었네요...
    - 내부 반복문이 끝나면 하나의 스트릭이 끝난 것이니 처음에 만든 임시 리스트에 이 스트릭의 길이, 사용한 프리즈 수, 시작 위치를 append() 합니다.
4. 스트릭이 이어지지 않을 때는 X인 날만 실패 날짜로 기록합니다.
5. 전체 순회가 다 끝나면 주어진 조건에 따라 임시 리스트 내에서 스트릭 길이 내림차순, 사용한 프리즈 수 오름차순, 시작 위치 오름차순으로 정렬하고 이 중 가장 먼저 오는 스트릭이 최장 스트릭이 됩니다.
    - 단순히 스트릭 길이가 같다고 해서 아무거나 선택하면 안 되기 때문에 이렇게 번거롭게 임시 배열에 모든 스트릭을 다 저장하는 방법을 사용했습니다. 상관없었다면 그냥 순회하면서 스트릭 길이가 가장 긴 것만 갱신하는 식으로 했을 것 같아요...
6. 가장 우선순위가 높은(=임시 배열 내에서 첫번째로 오는) 스트릭을 골라서 마지막에 실패 날짜를 추가해주고 return 합니다.
    - 이 때도 스트릭이 하나도 없는 사람이 있을 수 있으니 이런 경우에는 임시 배열에 [0, 0, 0] 을 추가했습니다.
7. 이런 식으로 모든 사람의 최장 스트릭을 구하고 똑같은 기준으로 정렬하되 이번에는 닉네임 사전 순(오름차순)까지 고려해서 한 번 더 정렬합니다.
8. 등수를 매기려고 하는데 만약 스트릭 길이, 사용한 프리즈 수, 시작 위치가 모두 동일하면 공동 n등이 됩니다. 또한 공동 1등이 4명이라고 가정했을 때 그 다음 순위는 5등이 아니라 2등입니다... 여기서부턴 너무 힘들어서 조건이 눈에 잘 안 들어오더라구요
9. 등수까지 모두 구했다면 이제 양식에 맞춰 출력해주면 끝입니다.

프로젝트로 알고리즘 문제 감각이 떨어져 있었는데 구현력에 불을 지피는 좋?은 문제였습니다.