### PR TITLE
이상민 / 8월 25일 / 개인문제

### DIFF
--- a/백준/Gold/33679. 세기의 대결/README.md
+++ b/백준/Gold/33679. 세기의 대결/README.md
@@ -1,0 +1,54 @@
+# [Gold V] 세기의 대결 - 33679 
+
+[문제 링크](https://www.acmicpc.net/problem/33679) 
+
+### 성능 요약
+
+메모리: 37020 KB, 시간: 240 ms
+
+### 분류
+
+다이나믹 프로그래밍, 브루트포스 알고리즘, 가장 긴 증가하는 부분 수열 문제
+
+### 제출 일자
+
+2025년 8월 25일 13:14:55
+
+### 문제 설명
+
+<p>영재와 해강이는 게임을 좋아한다. 두 친구는 요즘 리볼버 권총으로 보스 몬스터를 사격하는 게임에 푹 빠져 있다. 게임의 규칙은 다음과 같다.</p>
+
+<ol>
+	<li>리볼버 권총의 약실에는 총알이 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>N</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$N$</span></mjx-container>발 장전되어 있으며, 각 총알에는 위력을 나타내는 수가 적혀 있다.</li>
+	<li>사용자는 사격을 시작할 총알의 위치를 자유롭게 선택할 수 있다.</li>
+	<li>플레이어는 매 턴 총알 한 발을 보스에게 사격하거나 허공에 사격할 수 있다. 총알을 사격하면 약실이 시계방향으로 한 칸 회전한다.</li>
+	<li>보스 몬스터의 초기 방어력은 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c30"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>0</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$0$</span></mjx-container>이고, 총알에 피격될 때마다 해당 총알의 위력과 동일한 수치의 방어력을 갖게 된다. 예를 들어, 위력이 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c33"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>3</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$3$</span></mjx-container>인 총알에 피격되면 보스몬스터의 방어력은 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c33"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>3</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$3$</span></mjx-container>이 되고, 위력이 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c38"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>8</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$8$</span></mjx-container>인 총알에 피격되면 보스몬스터의 방어력은 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c38"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>8</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$8$</span></mjx-container>이 된다.</li>
+	<li>플레이어가 보스 몬스터의 방어력 이하의 위력을 가진 총알을 사격하게 되면 해당 총알이 반사되어 플레이어가 맞아 사망하게 된다.</li>
+	<li>보스 몬스터에게 총알 한 발을 사격할 때마다 플레이어는 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c31"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>1</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$1$</span></mjx-container>점을 획득하고, 반사된 총알에 플레이어가 맞아 사망하면 점수는 그 즉시 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mn class="mjx-n"><mjx-c class="mjx-c30"></mjx-c></mjx-mn></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mn>0</mn></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$0$</span></mjx-container>이 된다.</li>
+	<li>권총의 총알을 모두 사격하거나 반사된 총알에 플레이어가 맞아 사망하게 되면 게임이 종료된다.</li>
+</ol>
+
+<p style="text-align: center;"><img alt="" src="https://upload.acmicpc.net/fa28abe6-0de8-4019-a582-eaa3e4552660/-/preview/" style="height: 300px; width: 600px;"></p>
+
+<p style="text-align: center;">2번 규칙에 대한 그림</p>
+
+<p style="text-align: center;"><img alt="" src="https://upload.acmicpc.net/1121c6d8-9423-45a6-9024-28eaecb45d96/-/preview/" style="width: 600px; height: 265px;"></p>
+
+<p style="text-align: center;">3번 규칙에 대한 그림</p>
+
+<p>영재와 해강이는 서로 독립된 게임을 진행한다. 두 사람 모두 최선의 전략을 사용한다고 가정했을 때 두 사람 중 누가 더 높은 점수를 얻을지 맞춰보자.</p>
+
+### 입력 
+
+ <p>첫 번째 줄에 총알의 개수 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>N</mi></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$N$</span></mjx-container>이 주어진다.</p>
+
+<p>두 번째 줄에 영재의 총알의 위력 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-msub><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D434 TEX-I"></mjx-c></mjx-mi><mjx-script style="vertical-align: -0.15em;"><mjx-mn class="mjx-n" size="s"><mjx-c class="mjx-c31"></mjx-c></mjx-mn></mjx-script></mjx-msub><mjx-mo class="mjx-n"><mjx-c class="mjx-c2C"></mjx-c></mjx-mo><mjx-msub space="2"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D434 TEX-I"></mjx-c></mjx-mi><mjx-script style="vertical-align: -0.15em;"><mjx-mn class="mjx-n" size="s"><mjx-c class="mjx-c32"></mjx-c></mjx-mn></mjx-script></mjx-msub><mjx-mo class="mjx-n"><mjx-c class="mjx-c2C"></mjx-c></mjx-mo><mjx-mo class="mjx-n" space="2"><mjx-c class="mjx-c22EF"></mjx-c></mjx-mo><mjx-mo class="mjx-n" space="2"><mjx-c class="mjx-c2C"></mjx-c></mjx-mo><mjx-msub space="2"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D434 TEX-I"></mjx-c></mjx-mi><mjx-script style="vertical-align: -0.15em;"><mjx-mi class="mjx-i" size="s"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-script></mjx-msub></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>A</mi><mn>1</mn></msub><mo>,</mo><msub><mi>A</mi><mn>2</mn></msub><mo>,</mo><mo>⋯</mo><mo>,</mo><msub><mi>A</mi><mi>N</mi></msub></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$A_1, A_2, \cdots, A_N$</span></mjx-container>이 공백으로 구분되어 주어진다.</p>
+
+<p>세 번째 줄에 해강이의 총알의 위력 <mjx-container class="MathJax" jax="CHTML" style="font-size: 109%; position: relative;"><mjx-math class="MJX-TEX" aria-hidden="true"><mjx-msub><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D435 TEX-I"></mjx-c></mjx-mi><mjx-script style="vertical-align: -0.15em;"><mjx-mn class="mjx-n" size="s"><mjx-c class="mjx-c31"></mjx-c></mjx-mn></mjx-script></mjx-msub><mjx-mo class="mjx-n"><mjx-c class="mjx-c2C"></mjx-c></mjx-mo><mjx-msub space="2"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D435 TEX-I"></mjx-c></mjx-mi><mjx-script style="vertical-align: -0.15em;"><mjx-mn class="mjx-n" size="s"><mjx-c class="mjx-c32"></mjx-c></mjx-mn></mjx-script></mjx-msub><mjx-mo class="mjx-n"><mjx-c class="mjx-c2C"></mjx-c></mjx-mo><mjx-mo class="mjx-n" space="2"><mjx-c class="mjx-c22EF"></mjx-c></mjx-mo><mjx-mo class="mjx-n" space="2"><mjx-c class="mjx-c2C"></mjx-c></mjx-mo><mjx-msub space="2"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D435 TEX-I"></mjx-c></mjx-mi><mjx-script style="vertical-align: -0.15em;"><mjx-mi class="mjx-i" size="s"><mjx-c class="mjx-c1D441 TEX-I"></mjx-c></mjx-mi></mjx-script></mjx-msub></mjx-math><mjx-assistive-mml unselectable="on" display="inline"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>B</mi><mn>1</mn></msub><mo>,</mo><msub><mi>B</mi><mn>2</mn></msub><mo>,</mo><mo>⋯</mo><mo>,</mo><msub><mi>B</mi><mi>N</mi></msub></math></mjx-assistive-mml><span aria-hidden="true" class="no-mathjax mjx-copytext">$B_1, B_2, \cdots, B_N$</span></mjx-container>이 공백으로 구분되어 주어진다.</p>
+
+<p>총알은 입력된 순서대로 반시계방향을 이루고 있다.</p>
+
+### 출력 
+
+ <p>영재의 점수가 더 높다면 <span style="color:#e74c3c;"><code>YJ Win!</code></span>, 해강이의 점수가 더 높다면 <span style="color:#e74c3c;"><code>HG Win!</code></span>, 두 사람의 점수가 같다면 <span style="color:#e74c3c;"><code>Both Win!</code></span>을 출력한다.</p>
+

--- a/백준/Gold/33679. 세기의 대결/세기의 대결.py
+++ b/백준/Gold/33679. 세기의 대결/세기의 대결.py
@@ -1,0 +1,39 @@
+import sys
+from bisect import bisect_left
+from collections import deque
+input = sys.stdin.readline
+
+n = int(input())
+yj = deque(map(int, input().split()))
+hg = deque(map(int, input().split()))
+
+max_yj = max_hg = 0
+for _ in range(n):
+    yj_lis = []
+    hg_lis = []
+    for i in range(n):
+        yj_idx = bisect_left(yj_lis, yj[i])
+        if yj_idx == len(yj_lis):
+            yj_lis.append(yj[i])
+        else:
+            yj_lis[yj_idx] = yj[i]
+
+        hg_idx = bisect_left(hg_lis, hg[i])
+        if hg_idx == len(hg_lis):
+            hg_lis.append(hg[i])
+        else:
+            hg_lis[hg_idx] = hg[i]
+
+    if max_yj < len(yj_lis):
+        max_yj = len(yj_lis)
+    if max_hg < len(hg_lis):
+        max_hg = len(hg_lis)
+    yj.rotate()
+    hg.rotate()
+
+if max_yj > max_hg:
+    print("YJ Win!")
+elif max_yj < max_hg:
+    print("HG Win!")
+else:
+    print("Both Win!")


### PR DESCRIPTION
## 세기의 대결
문제의 조건에 맞춰서 이전 값보다 커지도록 최선의 전략을 취하면 결국 LIS를 구하는 문제가 됩니다. 
LIS 자체는 이전에 하던 것처럼 이분 탐색을 활용해서 log n의 시간 복잡도로 빠르게 구했습니다.
완전탐색으로 시작 지점을 하나씩 바꿔 가면서 LIS를 구하기 위해 각 사람의 리볼버를 덱으로 만들고 하나씩 rotate 시켰습니다.
최종 시간 복잡도는 nlog n 수준으로 비교적 n도 500으로 작기 때문에 시간제한은 여유로웠다고 생각합니다.